### PR TITLE
adds rate-limiting option to log pump

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ If you use multiline logging with raw, it's recommended to json encode the Data 
 * `MULTILINE_PATTERN` - pattern for multiline logging, see: [MULTILINE_MATCH](#multiline_match) (default: `^\s`)
 * `MULTILINE_FLUSH_AFTER` - maximum time between the first and last lines of a multiline log entry in milliseconds (default: 500)
 * `MULTILINE_SEPARATOR` - separator between lines for output (default: `\n`)
+* `RATE_LIMIT` - number of log lines emitted per second per route (default: unlimited)
 
 #### Raw Format
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 83a577e65396190336bd5117580f29dbf983a3e2fdc5732a111ae56f229ed978
-updated: 2017-11-07T22:39:32.638917215-06:00
+hash: 50a6e60f32b54f8c6b8ef5ee70504dbb36471b88a487b91dd034efde1b712a1f
+updated: 2018-11-07T13:11:54.481072-05:00
 imports:
 - name: github.com/docker/docker
   version: ad969f1aa782478725a7f338cf963fa82f484609
@@ -45,4 +45,8 @@ imports:
   version: a408501be4d17ee978c04a618e7a1b22af058c0e
   subpackages:
   - unix
+- name: golang.org/x/time
+  version: fbb02b2291d28baffd63558aa44b4b56f178d650
+  subpackages:
+  - rate
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,3 +7,6 @@ import:
 - package: golang.org/x/net
   subpackages:
   - websocket
+- package: golang.org/x/time
+  subpackages:
+  - rate

--- a/logspout.go
+++ b/logspout.go
@@ -36,6 +36,9 @@ func main() {
 	if getopt("BACKLOG", "") != "" {
 		fmt.Printf("backlog:%s ", getopt("BACKLOG", ""))
 	}
+	if getopt("RATE_LIMIT", "") != "" {
+		fmt.Printf("rateLimit:%s ", getopt("RATE_LIMIT", ""))
+	}
 	fmt.Printf("persist:%s\n", getopt("ROUTESPATH", "/mnt/routes"))
 
 	var jobs []string


### PR DESCRIPTION
On hosts with a large number of containers emitting a large number of
logs, the requests from logspout to `dockerd`'s socket can cause `dockerd`
to burn excessive CPU in JSON deserialization. This commit provides a
`RATE_LIMIT` environment variable that slows the rates of reads from the
socket.

---

cc @instacart/infra for review

I've tested this out locally as follows:
- spin up a nginx container: `docker run --name nginx -d -p 8080:80 nginx`
- start a TCP listener on port 8001 to receive syslogs: `nc -l 8001`
- in another terminal session, start a logspout container with this build: 

```
docker run --name logspout -e RATE_LIMIT=10 \
    -v=/var/run/docker.sock:/var/run/docker.sock \
    instacart/logspout tcp://$my_ip:8001
```
- in another terminal session, `docker logs -f nginx`
- in another terminal session, run a bunch of traffic with the following script
```bash
#!/bin/bash
i=0; while true; do
    curl -s -o /dev/null localhost:8080/$i
    i=$((i+1))
done
```

When I do this, I see only ~10 lines per second in the netcat listener and a full line-speed flow in the Nginx log container. Testing locally with `docker stats` it doesn't appear that we're creating any memory problems for `logspout`, and `dockerd` doesn't appear to eat up more memory either. It's harder to test on Docker for Mac that the CPU impact is improved, only because it's so trivial to run up the CPU _writing_ the logs without even attempting to read them.

I'll want to create a new container image build for this in https://github.com/instacart/dockerfiles and then test it while profiling `dockerd` as discussed in https://instacart.quip.com/21YRAYQOdkaV. I do want to get this upstreamed but we'll need to verify it does the job first.